### PR TITLE
Replace `self` return type with `static` return type of implementations

### DIFF
--- a/src/Http/GenericClientHttpException.php
+++ b/src/Http/GenericClientHttpException.php
@@ -18,7 +18,7 @@ class GenericClientHttpException extends ClientHttpExceptionAbstract
         return $this->httpStatusCode ?? $this->defaultStatusCode();
     }
 
-    public function setHttpStatus(?int $code): self
+    public function setHttpStatus(?int $code): static
     {
         $this->httpStatusCode = $code;
         return $this;

--- a/src/Support/SupportInternalContext.php
+++ b/src/Support/SupportInternalContext.php
@@ -24,7 +24,7 @@ trait SupportInternalContext
      *
      * Passing `null` with a key will remove the information under the key.
      */
-    public function pin(mixed $value, string|int|null $key = null): self
+    public function pin(mixed $value, string|int|null $key = null): static
     {
         if ($value === null) {
             if ($key !== null) {
@@ -51,7 +51,7 @@ trait SupportInternalContext
     /**
      * Replace current context with given one.
      */
-    public function replaceContext(array $context): self
+    public function replaceContext(array $context): static
     {
         $this->context = $context;
         return $this;

--- a/src/Support/SupportInternalExplanation.php
+++ b/src/Support/SupportInternalExplanation.php
@@ -20,7 +20,7 @@ trait SupportInternalExplanation
     /**
      * Add an explanation for internal purposes (logging, debugging, etc.).
      */
-    public function explain(?string $explanation): self
+    public function explain(?string $explanation): static
     {
         $this->explanation = $explanation;
         return $this;

--- a/src/Support/SupportPublicContext.php
+++ b/src/Support/SupportPublicContext.php
@@ -22,7 +22,7 @@ trait SupportPublicContext
      *
      * Passing `null` with a key will remove the information under the key.
      */
-    public function pass(mixed $value, string|int|null $key = null): self
+    public function pass(mixed $value, string|int|null $key = null): static
     {
         if ($value === null) {
             if ($key !== null) {
@@ -49,7 +49,7 @@ trait SupportPublicContext
     /**
      * Completely replace current client-facing context with given one.
      */
-    public function replacePublicContext(array $context): self
+    public function replacePublicContext(array $context): static
     {
         $this->publicContext = $context;
         return $this;

--- a/src/Support/SupportPublicConveying.php
+++ b/src/Support/SupportPublicConveying.php
@@ -31,7 +31,7 @@ trait SupportPublicConveying
         mixed $meta = null,
         ?int $status = null,
         ?string $code = null,
-    ): self {
+    ): static {
         return $this->pass(new ErrorContainer(
             message: $message ?? $this->getDefaultMessageToConvey(),
             source: $source,

--- a/src/Support/SupportTagging.php
+++ b/src/Support/SupportTagging.php
@@ -22,7 +22,7 @@ trait SupportTagging
      *
      * Both plain string tags and key-tag pairs are supported.
      */
-    public function tag(string $tag, string|int|null $key = null): self
+    public function tag(string $tag, string|int|null $key = null): static
     {
         if ($key !== null) {
             $this->tags[$key] = $tag;
@@ -43,7 +43,7 @@ trait SupportTagging
     /**
      * Replace current tags with given ones.
      */
-    public function replaceTags(array $tags): self
+    public function replaceTags(array $tags): static
     {
         $this->tags = [];
         // iterate over the keys for type safety


### PR DESCRIPTION
This possibly improves static code analysis and IDE experience.

But there is a catch! This PhpStorm issue prevents the release of this feature: [WI-74884](https://youtrack.jetbrains.com/issue/WI-74884/Static-return-type-in-trait-methods-implementing-interfaces-with-self-return-type-triggers-false-positive-error)
